### PR TITLE
:bookmark: v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fixed the /auth/login response status to 200 OK instead of 201 Created, aligning with REST conventions
 - Added a global response interceptor that strips `passwordHash` from any response body as a defense-in-depth measure against accidental leaks
 - Fixed authentication DTOs to trim whitespace around email and username so leading or trailing spaces no longer break lookups or duplicate-detection
+- Removed an unused `ConfigService` dependency from the authentication service
 - Updated the local docker-compose to sync npm dependencies, regenerate the Prisma client, and apply database migrations on container start
 - Updated the local docker-compose host port mapping to track the `PORT` env variable so non-default ports stay reachable
 - Configured the local docker-compose backend service with `init: true` for proper signal handling and zombie reaping

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.1.1
 
 - Fixed the /auth/login response status to 200 OK instead of 201 Created, aligning with REST conventions
+- Added a global response interceptor that strips `passwordHash` from any response body as a defense-in-depth measure against accidental leaks
 - Updated the local docker-compose to sync npm dependencies, regenerate the Prisma client, and apply database migrations on container start
 - Updated the local docker-compose host port mapping to track the `PORT` env variable so non-default ports stay reachable
 - Configured the local docker-compose backend service with `init: true` for proper signal handling and zombie reaping

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fixed the /auth/login response status to 200 OK instead of 201 Created, aligning with REST conventions
 - Added a global response interceptor that strips `passwordHash` from any response body as a defense-in-depth measure against accidental leaks
+- Fixed authentication DTOs to trim whitespace around email and username so leading or trailing spaces no longer break lookups or duplicate-detection
 - Updated the local docker-compose to sync npm dependencies, regenerate the Prisma client, and apply database migrations on container start
 - Updated the local docker-compose host port mapping to track the `PORT` env variable so non-default ports stay reachable
 - Configured the local docker-compose backend service with `init: true` for proper signal handling and zombie reaping

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.1.1
 
+- Fixed the /auth/login response status to 200 OK instead of 201 Created, aligning with REST conventions
 - Updated the local docker-compose to sync npm dependencies, regenerate the Prisma client, and apply database migrations on container start
 - Updated the local docker-compose host port mapping to track the `PORT` env variable so non-default ports stay reachable
 - Configured the local docker-compose backend service with `init: true` for proper signal handling and zombie reaping

--- a/src/app.setup.ts
+++ b/src/app.setup.ts
@@ -2,6 +2,7 @@ import { INestApplication, ValidationPipe } from '@nestjs/common';
 import helmet from 'helmet';
 
 import { AppExceptionFilter } from './common/filters/app-exception.filter';
+import { StripSensitiveInterceptor } from './common/interceptors/strip-sensitive.interceptor';
 import { validationExceptionFactory } from './common/validation/validation-exception.factory';
 
 export function configureApp(app: INestApplication) {
@@ -18,6 +19,8 @@ export function configureApp(app: INestApplication) {
   }
 
   app.useGlobalFilters(new AppExceptionFilter());
+
+  app.useGlobalInterceptors(new StripSensitiveInterceptor());
 
   app.useGlobalPipes(
     new ValidationPipe({

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Post } from '@nestjs/common';
+import { Body, Controller, HttpCode, HttpStatus, Post } from '@nestjs/common';
 import { Throttle } from '@nestjs/throttler';
 
 import { AuthService } from './auth.service';
@@ -16,6 +16,7 @@ export class AuthController {
     return this.authService.register(registerDto);
   }
 
+  @HttpCode(HttpStatus.OK)
   @Post('login')
   login(@Body() loginDto: LoginDto): Promise<AuthResponse> {
     return this.authService.login(loginDto);

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -1,4 +1,3 @@
-import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
 import { Test, TestingModule } from '@nestjs/testing';
 import { User, UserRole, UserStatus } from '@prisma/client';
@@ -54,7 +53,6 @@ describe('AuthService', () => {
         AuthService,
         { provide: UsersService, useValue: usersService },
         { provide: JwtService, useValue: jwtService },
-        { provide: ConfigService, useValue: {} },
       ],
     }).compile();
 

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,5 +1,4 @@
 import { HttpStatus, Injectable } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
 import { UserStatus } from '@prisma/client';
 import * as bcrypt from 'bcrypt';
@@ -17,7 +16,6 @@ const PASSWORD_SALT_ROUNDS = 12;
 @Injectable()
 export class AuthService {
   constructor(
-    private readonly configService: ConfigService,
     private readonly jwtService: JwtService,
     private readonly usersService: UsersService,
   ) {}

--- a/src/auth/dto/login.dto.ts
+++ b/src/auth/dto/login.dto.ts
@@ -1,6 +1,10 @@
+import { Transform } from 'class-transformer';
 import { IsEmail, IsString, MinLength } from 'class-validator';
 
+import { trim } from '../../common/transformers/trim.transformer';
+
 export class LoginDto {
+  @Transform(trim)
   @IsEmail()
   email: string;
 

--- a/src/auth/dto/register.dto.ts
+++ b/src/auth/dto/register.dto.ts
@@ -1,9 +1,14 @@
+import { Transform } from 'class-transformer';
 import { IsEmail, IsNotEmpty, IsString, MinLength } from 'class-validator';
 
+import { trim } from '../../common/transformers/trim.transformer';
+
 export class RegisterDto {
+  @Transform(trim)
   @IsEmail()
   email: string;
 
+  @Transform(trim)
   @IsString()
   @IsNotEmpty()
   username: string;

--- a/src/common/interceptors/strip-sensitive.interceptor.spec.ts
+++ b/src/common/interceptors/strip-sensitive.interceptor.spec.ts
@@ -1,0 +1,83 @@
+import { CallHandler, ExecutionContext } from '@nestjs/common';
+import { firstValueFrom, of } from 'rxjs';
+
+import { StripSensitiveInterceptor } from './strip-sensitive.interceptor';
+
+describe('StripSensitiveInterceptor', () => {
+  let interceptor: StripSensitiveInterceptor;
+
+  beforeEach(() => {
+    interceptor = new StripSensitiveInterceptor();
+  });
+
+  function run(value: unknown): Promise<unknown> {
+    const context = {} as ExecutionContext;
+    const next: CallHandler = { handle: () => of(value) };
+    return firstValueFrom(interceptor.intercept(context, next));
+  }
+
+  it('passes primitive values through unchanged', async () => {
+    expect(await run('hello')).toBe('hello');
+    expect(await run(42)).toBe(42);
+    expect(await run(true)).toBe(true);
+    expect(await run(null)).toBeNull();
+    expect(await run(undefined)).toBeUndefined();
+  });
+
+  it('strips passwordHash from a top-level object', async () => {
+    const result = await run({
+      id: 'user-1',
+      email: 'a@b.com',
+      passwordHash: 'secret',
+    });
+
+    expect(result).toEqual({ id: 'user-1', email: 'a@b.com' });
+  });
+
+  it('strips passwordHash from nested objects', async () => {
+    const result = await run({
+      accessToken: 'token',
+      user: {
+        id: 'user-1',
+        passwordHash: 'secret',
+      },
+    });
+
+    expect(result).toEqual({
+      accessToken: 'token',
+      user: { id: 'user-1' },
+    });
+  });
+
+  it('strips passwordHash from each item in an array', async () => {
+    const result = await run([
+      { id: '1', passwordHash: 'a' },
+      { id: '2', passwordHash: 'b' },
+    ]);
+
+    expect(result).toEqual([{ id: '1' }, { id: '2' }]);
+  });
+
+  it('preserves Date instances instead of flattening them to empty objects', async () => {
+    const createdAt = new Date('2024-01-01T00:00:00Z');
+
+    const result = (await run({ id: '1', createdAt })) as {
+      id: string;
+      createdAt: Date;
+    };
+
+    expect(result).toEqual({ id: '1', createdAt });
+    expect(result.createdAt).toBeInstanceOf(Date);
+  });
+
+  it('leaves objects untouched when they contain no sensitive fields', async () => {
+    const input = {
+      id: '1',
+      email: 'a@b.com',
+      nested: { count: 3 },
+      tags: ['one', 'two'],
+    };
+
+    expect(await run(input)).toEqual(input);
+  });
+});

--- a/src/common/interceptors/strip-sensitive.interceptor.ts
+++ b/src/common/interceptors/strip-sensitive.interceptor.ts
@@ -1,0 +1,44 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  NestInterceptor,
+} from '@nestjs/common';
+import { Observable, map } from 'rxjs';
+
+const SENSITIVE_FIELDS = new Set<string>(['passwordHash']);
+
+@Injectable()
+export class StripSensitiveInterceptor implements NestInterceptor {
+  intercept(
+    _context: ExecutionContext,
+    next: CallHandler,
+  ): Observable<unknown> {
+    return next.handle().pipe(map((data) => sanitize(data)));
+  }
+}
+
+function sanitize(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(sanitize);
+  }
+  if (isPlainObject(value)) {
+    const out: Record<string, unknown> = {};
+    for (const [key, nested] of Object.entries(value)) {
+      if (SENSITIVE_FIELDS.has(key)) {
+        continue;
+      }
+      out[key] = sanitize(nested);
+    }
+    return out;
+  }
+  return value;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== 'object') {
+    return false;
+  }
+  const proto: unknown = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}

--- a/src/common/transformers/trim.transformer.ts
+++ b/src/common/transformers/trim.transformer.ts
@@ -1,0 +1,5 @@
+import type { TransformFnParams } from 'class-transformer';
+
+export function trim({ value }: TransformFnParams): unknown {
+  return typeof value === 'string' ? value.trim() : value;
+}

--- a/test/auth.e2e-spec.ts
+++ b/test/auth.e2e-spec.ts
@@ -219,6 +219,32 @@ describe('Auth flow (e2e)', () => {
     });
   });
 
+  it('trims whitespace around the email and username on registration', async () => {
+    const response = await request(app.getHttpServer())
+      .post('/auth/register')
+      .send({
+        email: '  trimmed@example.com  ',
+        username: '  trimmeduser  ',
+        password: 'password123',
+      });
+    const body = response.body as AuthSuccessResponse;
+
+    expect(response.status).toBe(201);
+    expect(body.user).toMatchObject({
+      email: 'trimmed@example.com',
+      username: 'trimmeduser',
+    });
+
+    const loginResponse = await request(app.getHttpServer())
+      .post('/auth/login')
+      .send({
+        email: '  trimmed@example.com  ',
+        password: 'password123',
+      });
+
+    expect(loginResponse.status).toBe(200);
+  });
+
   it('rejects access to a protected route without a token', async () => {
     const response = await request(app.getHttpServer()).get('/users/me');
     const body = response.body as ErrorResponse;

--- a/test/auth.e2e-spec.ts
+++ b/test/auth.e2e-spec.ts
@@ -96,7 +96,7 @@ describe('Auth flow (e2e)', () => {
       });
     const body = response.body as AuthSuccessResponse;
 
-    expect([200, 201]).toContain(response.status);
+    expect(response.status).toBe(200);
     expect(body.accessToken).toEqual(expect.any(String));
     expect(body.user).toMatchObject({
       email: 'login@example.com',


### PR DESCRIPTION
- Fixed the /auth/login response status to 200 OK instead of 201 Created, aligning with REST conventions
- Added a global response interceptor that strips `passwordHash` from any response body as a defense-in-depth measure against accidental leaks
- Fixed authentication DTOs to trim whitespace around email and username so leading or trailing spaces no longer break lookups or duplicate-detection
- Removed an unused `ConfigService` dependency from the authentication service
- Updated the local docker-compose to sync npm dependencies, regenerate the Prisma client, and apply database migrations on container start
- Updated the local docker-compose host port mapping to track the `PORT` env variable so non-default ports stay reachable
- Configured the local docker-compose backend service with `init: true` for proper signal handling and zombie reaping
- Updated the deploy-dev workflow to trigger on CI completion via `workflow_run` rather than directly on push to dev
- Updated the staging release workflow to build a versioned `:vX.Y.Z` image from the tagged commit and promote it to `:staging`, replacing the previous re-tag of the dev image
- Updated the production deploy workflow to promote the immutable `:vX.Y.Z` image to `:prod` after validating the tag is strict semver and contained in main
- Added tag validation in staging and production workflows: semver regex plus `git merge-base` ancestry check against `origin/main`
- Updated Dokploy webhook calls to send a JSON payload describing the image and release identifier
- Updated the `docker/build-push-action` to v7 across deployment workflows
